### PR TITLE
Add placement checks for plot/pen builds

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,4 +9,5 @@ dependencies {
   if(enableGraalNative == 'true') {
     implementation "io.github.berstanio:gdx-svmhelper-annotations:$graalHelperVersion"
   }
+  testImplementation 'junit:junit:4.13.2'
 }

--- a/core/src/main/java/com/farmgame/game/Farm.java
+++ b/core/src/main/java/com/farmgame/game/Farm.java
@@ -150,22 +150,37 @@ public class Farm {
         setWateringSystem(true);
     }
 
-    public void addPlot(int x, int y, Plot plot) {
-        if (x < 0 || x >= width || y < 0 || y >= height) return;
-        plots.put(new GridPoint2(x, y), plot);
+    public boolean addPlot(int x, int y, Plot plot) {
+        if (x < 0 || x >= width || y < 0 || y >= height) return false;
+        GridPoint2 pos = new GridPoint2(x, y);
+        if (plots.containsKey(pos) || animalPens.containsKey(pos)) {
+            return false;
+        }
+        plots.put(pos, plot);
+        return true;
     }
 
     public void removePlot(int x, int y) {
         plots.remove(new GridPoint2(x, y));
     }
 
-    public void addAnimalPen(int x, int y, AnimalPen pen) {
-        if (x < 0 || x >= penWidth || y < 0 || y >= penHeight) return;
-        animalPens.put(new GridPoint2(x, y), pen);
+    public boolean addAnimalPen(int x, int y, AnimalPen pen) {
+        if (x < 0 || x >= penWidth || y < 0 || y >= penHeight) return false;
+        GridPoint2 pos = new GridPoint2(x, y);
+        if (animalPens.containsKey(pos) || plots.containsKey(pos)) {
+            return false;
+        }
+        animalPens.put(pos, pen);
+        return true;
     }
 
     public void removeAnimalPen(int x, int y) {
         animalPens.remove(new GridPoint2(x, y));
+    }
+
+    public boolean isCoordinateEmpty(int x, int y) {
+        GridPoint2 pos = new GridPoint2(x, y);
+        return !plots.containsKey(pos) && !animalPens.containsKey(pos);
     }
 
     public Map<GridPoint2, Plot> getPlotMap() {

--- a/core/src/main/java/com/farmgame/screen/GameScreen.java
+++ b/core/src/main/java/com/farmgame/screen/GameScreen.java
@@ -1497,7 +1497,15 @@ public class GameScreen implements Screen {
 
     private void attemptBuildPlot(int x, int y) {
         Plot plot = farm.getPlot(x, y);
-        if (plot == null || !plot.isBlocked() || !hasUnlockedNeighborPlot(x, y)) {
+        if (plot == null) {
+            if (!farm.isCoordinateEmpty(x, y)) {
+                MessageManager.warning("To miejsce jest już zajęte!");
+                return;
+            }
+            MessageManager.warning("Nie można tu zbudować pola!");
+            return;
+        }
+        if (!plot.isBlocked() || !hasUnlockedNeighborPlot(x, y)) {
             MessageManager.warning("Nie można tu zbudować pola!");
             return;
         }
@@ -1516,7 +1524,15 @@ public class GameScreen implements Screen {
 
     private void attemptBuildPen(int x, int y) {
         AnimalPen pen = farm.getAnimalPen(x, y);
-        if (pen == null || !pen.isBlocked() || !hasUnlockedNeighborPen(x, y)) {
+        if (pen == null) {
+            if (!farm.isCoordinateEmpty(x, y)) {
+                MessageManager.warning("To miejsce jest już zajęte!");
+                return;
+            }
+            MessageManager.warning("Nie można tu zbudować zagrody!");
+            return;
+        }
+        if (!pen.isBlocked() || !hasUnlockedNeighborPen(x, y)) {
             MessageManager.warning("Nie można tu zbudować zagrody!");
             return;
         }

--- a/core/src/test/java/com/farmgame/game/FarmPlacementTest.java
+++ b/core/src/test/java/com/farmgame/game/FarmPlacementTest.java
@@ -1,0 +1,37 @@
+import com.farmgame.game.*;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class FarmPlacementTest {
+    @Test
+    public void testAddPlotFailsWhenOccupied() {
+        Farm farm = new Farm(2, 2, 2, 2);
+        Plot newPlot = new Plot();
+        assertFalse("Should not add plot on occupied cell", farm.addPlot(0, 0, newPlot));
+    }
+
+    @Test
+    public void testAddPlotSucceedsWhenCellFree() {
+        Farm farm = new Farm(2, 2, 2, 2);
+        farm.removePlot(1, 1);
+        farm.removeAnimalPen(1, 1);
+        Plot newPlot = new Plot();
+        assertTrue("Should add plot on empty cell", farm.addPlot(1, 1, newPlot));
+    }
+
+    @Test
+    public void testAddAnimalPenFailsWhenOccupied() {
+        Farm farm = new Farm(2, 2, 2, 2);
+        AnimalPen pen = new AnimalPen(0, 0);
+        assertFalse("Should not add pen on occupied cell", farm.addAnimalPen(0, 0, pen));
+    }
+
+    @Test
+    public void testAddAnimalPenSucceedsWhenCellFree() {
+        Farm farm = new Farm(2, 2, 2, 2);
+        farm.removePlot(1, 1);
+        farm.removeAnimalPen(1, 1);
+        AnimalPen pen = new AnimalPen(1, 1);
+        assertTrue("Should add pen on empty cell", farm.addAnimalPen(1, 1, pen));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure Farm.addPlot/addAnimalPen only add when location empty
- show warning message when build placement is invalid
- expose helper `isCoordinateEmpty`
- add JUnit tests for placement checks
- add JUnit dependency for core

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68595ef0b8e0832e9ff1fc0b701c9297