### PR TITLE
Render plant growth textures

### DIFF
--- a/core/src/main/java/com/farmgame/game/Plant.java
+++ b/core/src/main/java/com/farmgame/game/Plant.java
@@ -1,5 +1,7 @@
 package com.farmgame.game;
 
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+
 public class Plant {
     private final PlantType type;
     private float currentGrowthTime;
@@ -122,6 +124,10 @@ public class Plant {
         if (percent < 0.33f) return GrowthStage.PLANTED;
         else if (percent < 1.00f) return GrowthStage.GROWING;
         else return GrowthStage.READY;
+    }
+
+    public TextureRegion getTexture() {
+        return type.getTextureForStage(getStage());
     }
 
 }

--- a/core/src/main/java/com/farmgame/game/PlantType.java
+++ b/core/src/main/java/com/farmgame/game/PlantType.java
@@ -1,6 +1,10 @@
 package com.farmgame.game;
 
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.farmgame.game.Plant.GrowthStage;
 
 public class PlantType {
     private final String name;
@@ -9,6 +13,7 @@ public class PlantType {
     private final int seedPrice;
     private final int sellPrice;
     private final int requiredLevel;
+    private final TextureRegion[] stageRegions;
 
     public PlantType(String name, float growthTime, Color color, int seedPrice, int sellPrice, int requiredLevel) {
         this.name = name;
@@ -17,6 +22,7 @@ public class PlantType {
         this.seedPrice = seedPrice;
         this.sellPrice = sellPrice;
         this.requiredLevel = requiredLevel;
+        this.stageRegions = generateStageTextures(color);
     }
 
     public String getName() {
@@ -45,6 +51,33 @@ public class PlantType {
 
     public static PlantType getByName(String name) {
         return PlantDatabase.getByName(name);
+    }
+
+    private TextureRegion[] generateStageTextures(Color base) {
+        int size = 16;
+        Pixmap pixmap = new Pixmap(size * 3, size, Pixmap.Format.RGBA8888);
+        for (int i = 0; i < 3; i++) {
+            float brightness = 0.6f + 0.2f * i;
+            Color c = new Color(base);
+            c.mul(brightness);
+            pixmap.setColor(c);
+            pixmap.fillRectangle(i * size, 0, size, size);
+        }
+        Texture texture = new Texture(pixmap);
+        TextureRegion[] regions = new TextureRegion[3];
+        for (int i = 0; i < 3; i++) {
+            regions[i] = new TextureRegion(texture, i * size, 0, size, size);
+        }
+        pixmap.dispose();
+        return regions;
+    }
+
+    public TextureRegion getTextureForStage(Plant.GrowthStage stage) {
+        return switch (stage) {
+            case PLANTED -> stageRegions[0];
+            case GROWING -> stageRegions[1];
+            case READY -> stageRegions[2];
+        };
     }
 
     @Override

--- a/core/src/main/java/com/farmgame/screen/GameScreen.java
+++ b/core/src/main/java/com/farmgame/screen/GameScreen.java
@@ -1117,13 +1117,6 @@ public class GameScreen implements Screen {
                 // Plant
                 if (plot.getPlant() != null) {
                     Plant plant = plot.getPlant();
-                    float centerX = iso.x + TILE_WIDTH / 4f;
-                    float centerY = iso.y + TILE_HEIGHT / 4f;
-                    float size = TILE_WIDTH / 2f;
-
-                    shapeRenderer.setColor(plant.getType().getColor());
-                    drawDiamond(centerX, centerY, (int)size, TILE_HEIGHT / 2);
-
                     // Kropla wody
                     if (plant.isWatered() || plant.isAutoWatered()) {
                         float waterSize = TILE_WIDTH / 4f;
@@ -1204,6 +1197,20 @@ public class GameScreen implements Screen {
 
         batch.begin();
         batch.setColor(Color.WHITE);
+        // Rysowanie tekstur roślin
+        for (int x = 0; x < farm.getWidth(); x++) {
+            for (int y = 0; y < farm.getHeight(); y++) {
+                Plot plot = farm.getPlot(x, y);
+                if (plot == null || plot.getPlant() == null) continue;
+
+                Vector2 iso = gridToIso(x, y, TILE_WIDTH, TILE_HEIGHT, offsetX, offsetY);
+                float centerX = iso.x + TILE_WIDTH / 4f;
+                float centerY = iso.y + TILE_HEIGHT / 4f;
+                float size = TILE_WIDTH / 2f;
+
+                batch.draw(plot.getPlant().getTexture(), centerX, centerY, size, TILE_HEIGHT / 2f);
+            }
+        }
         // Tekst do plot
         for (int x = 0; x < farm.getWidth(); x++) {
             for (int y = 0; y < farm.getHeight(); y++) {


### PR DESCRIPTION
## Summary
- add dynamic growth stage textures to `PlantType`
- allow `Plant` to expose the texture for its current stage
- draw plant textures in `GameScreen` instead of colored shapes

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68597074cbe8832eadc873d0ca53f38d